### PR TITLE
Configuring compiler for post-password-change

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
 module.exports = {
     'client-credentials-exchange': require('./lib/compilers/client_credentials_exchange'),
     'password-exchange': require('./lib/compilers/password_exchange'),
+    'post-change-password': require('./lib/compilers/user-registration'),
     'pre-user-registration': require('./lib/compilers/user-registration'),
     'post-user-registration': require('./lib/compilers/user-registration'),
     'generic': require('./lib/compilers/generic'),

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "http://tomasz.janczuk.org",
     "twitter": "tjanczuk"
   },
-  "version": "5.4.0",
+  "version": "5.5.0",
   "description": "Webtask compilers for Auth0 platform extensibility points",
   "engines": {
     "node": ">= 4.3"


### PR DESCRIPTION
Post Change Password utilizes the same compiler as user registration.  For now we will use the same compiler until it requires further change.