### PR TITLE
[DO NOT MERGE] Adding custom errors for client credentials hook.

### DIFF
--- a/lib/compilers/client_credentials_exchange.js
+++ b/lib/compilers/client_credentials_exchange.js
@@ -35,7 +35,8 @@ const ERROR_TO_RESULT_MAP =  {
         data: {
             error: 'invalid_request',
             error_code: err.code,
-            error_description: err.message
+            error_description: err.message,
+            stack: err.stack,
         }
     }),
     [InvalidScopeError.name]: (err) => ({
@@ -43,7 +44,8 @@ const ERROR_TO_RESULT_MAP =  {
         data: {
             error: 'invalid_scope',
             error_code: err.code,
-            error_description: err.message
+            error_description: err.message,
+            stack: err.stack,
         }
     }),
     [ServerError.name]: (err) => ({
@@ -51,7 +53,8 @@ const ERROR_TO_RESULT_MAP =  {
         data: {
             error: 'server_error',
             error_code: err.code,
-            error_description: err.message
+            error_description: err.message,
+            stack: err.stack,
         }
     })
 };
@@ -68,7 +71,10 @@ function mapError(err) {
 
     if(resultFunc) return resultFunc(err);
 
-    return { result: "user_error", data: err };
+    return { result: "user_error", data: {
+        message: err.message,
+        stack: err.stack
+    } };
 }
 
 module.exports = Factory.createCompiler(clientCredentialsExchangeHandler, PRELUDE_ITEMS);

--- a/lib/compilers/client_credentials_exchange.js
+++ b/lib/compilers/client_credentials_exchange.js
@@ -3,22 +3,40 @@
 const Authz = require('../authorization');
 const Factory = require('./compilerFactory');
 
-class InvalidRequestError extends Error {
-    constructor(message) {
+class BaseError extends Error {
+    constructor(code, message) {
         super(message);
-        this.name = "InvalidRequestError";
+        this.code = code;
+        this.name = this.constructor.name;
     }
 }
 
-function addPrelude(script) {
-    return `
-        ${InvalidRequestError.toString()}
-        ${script}
-    `;
+class InvalidRequestError extends BaseError {
+    constructor(code, message) {
+        super(code, message);
+    }
 }
 
-module.exports = Factory.createCompiler(clientCredentialsExchangeHandler, addPrelude);
+class InvalidScopeError extends BaseError {
+    constructor(code, message) {
+        super(code, message);
+    }
+}
 
+class ServerError extends BaseError {
+    constructor(code, message) {
+        super(code, message);
+    }
+}
+
+const PRELUDE_ITEMS = [
+    BaseError,
+    InvalidRequestError,
+    InvalidScopeError,
+    ServerError
+];
+
+module.exports = Factory.createCompiler(clientCredentialsExchangeHandler, PRELUDE_ITEMS);
 
 function clientCredentialsExchangeHandler (func, webtaskContext, cb) {
     return Authz.is_authorized(webtaskContext, error => {

--- a/lib/compilers/client_credentials_exchange.js
+++ b/lib/compilers/client_credentials_exchange.js
@@ -3,12 +3,27 @@
 const Authz = require('../authorization');
 const Factory = require('./compilerFactory');
 
-module.exports = Factory.createCompiler(clientCredentialsExchangeHandler);
+class InvalidRequestError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = "InvalidRequestError";
+    }
+}
+
+function addPrelude(script) {
+    return `
+        ${InvalidRequestError.toString()}
+        ${script}
+    `;
+}
+
+module.exports = Factory.createCompiler(clientCredentialsExchangeHandler, addPrelude);
+
 
 function clientCredentialsExchangeHandler (func, webtaskContext, cb) {
     return Authz.is_authorized(webtaskContext, error => {
         if (error) return cb(error);
-        
+
         if (typeof webtaskContext.body !== 'object')
             return cb(new Error('Body received by extensibility point is not an object'));
         if (typeof webtaskContext.body.client !== 'object')
@@ -19,11 +34,26 @@ function clientCredentialsExchangeHandler (func, webtaskContext, cb) {
             return cb(new Error('Body .audience received by extensibility point is not a string'));
 
         const context = typeof webtaskContext.body.context === 'object'
-            ?   webtaskContext.body.context
-            :   {};
-            
+              ?   webtaskContext.body.context
+              :   {};
+
         context.webtask = webtaskContext;
 
-        return func(webtaskContext.body.client, webtaskContext.body.scope, webtaskContext.body.audience, context, cb);
-    });
+        function wrappedCallback(err, data) {
+            if(err && err.name === 'InvalidRequestError') {
+                return cb(null, { result: "oauth_error", data: {
+                    error: 'invalid_request',
+                    error_description: err.message
+                }});
+            }
+
+            if(err) {
+                return cb(null, { result: "user_error", data: err });
+            }
+
+            cb(null, { result: "success", data });
+        }
+
+        return func(webtaskContext.body.client, webtaskContext.body.scope, webtaskContext.body.audience, context, wrappedCallback);
+  });
 }

--- a/lib/compilers/client_credentials_exchange.js
+++ b/lib/compilers/client_credentials_exchange.js
@@ -29,12 +29,47 @@ class ServerError extends BaseError {
     }
 }
 
+const ERROR_TO_RESULT_MAP =  {
+    [InvalidRequestError.name]: (err) => ({
+        result: 'oauth_error',
+        data: {
+            error: 'invalid_request',
+            error_code: err.code,
+            error_description: err.message
+        }
+    }),
+    [InvalidScopeError.name]: (err) => ({
+        result: 'oauth_error',
+        data: {
+            error: 'invalid_scope',
+            error_code: err.code,
+            error_description: err.message
+        }
+    }),
+    [ServerError.name]: (err) => ({
+        result: 'oauth_error',
+        data: {
+            error: 'server_error',
+            error_code: err.code,
+            error_description: err.message
+        }
+    })
+};
+
 const PRELUDE_ITEMS = [
     BaseError,
     InvalidRequestError,
     InvalidScopeError,
     ServerError
 ];
+
+function mapError(err) {
+    const resultFunc = ERROR_TO_RESULT_MAP[err.name];
+
+    if(resultFunc) return resultFunc(err);
+
+    return { result: "user_error", data: err };
+}
 
 module.exports = Factory.createCompiler(clientCredentialsExchangeHandler, PRELUDE_ITEMS);
 
@@ -58,15 +93,8 @@ function clientCredentialsExchangeHandler (func, webtaskContext, cb) {
         context.webtask = webtaskContext;
 
         function wrappedCallback(err, data) {
-            if(err && err.name === 'InvalidRequestError') {
-                return cb(null, { result: "oauth_error", data: {
-                    error: 'invalid_request',
-                    error_description: err.message
-                }});
-            }
-
             if(err) {
-                return cb(null, { result: "user_error", data: err });
+                return cb(null, mapError(err));
             }
 
             cb(null, { result: "success", data });

--- a/lib/compilers/compilerFactory.js
+++ b/lib/compilers/compilerFactory.js
@@ -5,6 +5,13 @@ module.exports = {
     createCompiler,
 };
 
+function addPreludeItems(script, items) {
+  return `
+        ${items.map(i => i.toString()).join("\n")}
+        ${script}
+    `;
+}
+
 /**
  * Factory Function to be used internally by Extensibility Points Implementations
  * Creates an extensibility point compiler.
@@ -13,7 +20,7 @@ module.exports = {
  * @param  {Function} handler The Extensibility Point handler
  * @return {Function}         The Extensibility Point Compiler
  */
-function createCompiler(handler, addPrelude) {
+function createCompiler(handler, preludeItems = []) {
     /**
      * Extensibility Point Compiler.
      * Receives the webtask code and returns the webtask function to be executed
@@ -21,7 +28,7 @@ function createCompiler(handler, addPrelude) {
      * @param  {Function} cb      The callback
      */
     return function extensibilityPointCompiler(options, cb) {
-        const script = addPrelude ? addPrelude(options.script) : options.script;
+        const script = addPreludeItems(options.script, preludeItems);
 
         options.nodejsCompiler(script, function (error, func) {
             if (error) {

--- a/lib/compilers/compilerFactory.js
+++ b/lib/compilers/compilerFactory.js
@@ -13,7 +13,7 @@ module.exports = {
  * @param  {Function} handler The Extensibility Point handler
  * @return {Function}         The Extensibility Point Compiler
  */
-function createCompiler(handler) {
+function createCompiler(handler, addPrelude) {
     /**
      * Extensibility Point Compiler.
      * Receives the webtask code and returns the webtask function to be executed
@@ -21,7 +21,9 @@ function createCompiler(handler) {
      * @param  {Function} cb      The callback
      */
     return function extensibilityPointCompiler(options, cb) {
-        options.nodejsCompiler(options.script, function (error, func) {
+        const script = addPrelude ? addPrelude(options.script) : options.script;
+
+        options.nodejsCompiler(script, function (error, func) {
             if (error) {
                 // Return a wrapped webtask function that will generate an error
                 // so that we have a consistent pathway to error reporting

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-ext-compilers",
-  "version": "5.5.2",
+  "version": "5.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/client-credentials-exchange.tests.js
+++ b/test/client-credentials-exchange.tests.js
@@ -296,6 +296,31 @@ describe('client-credentials-exchange', function () {
         });
     });
 
+    it('transforms vanilla Errors into an error payload', function (done) {
+        compiler({
+            nodejsCompiler,
+            script: `module.exports = function(client, scope, audience, context, cb) {
+                        cb(new Error('vanilla error'));
+                     };`
+        }, function (error, func) {
+            Assert.ifError(error);
+
+            simulate(func, {
+                body: { client: { id: 'client' }, audience: 'audience' },
+                headers: {},
+                method: 'POST',
+            }, function (error, envelope) {
+                Assert.ifError(error);
+                Assert.ok(envelope);
+                const { result, data } = envelope;
+                Assert.ok(data);
+                Assert.equal(result, 'user_error');
+                Assert.equal(data.message, 'vanilla error');
+                done();
+            });
+        });
+    });
+
     it('transforms InvalidRequestErrors into an error payload', function (done) {
         compiler({
             nodejsCompiler,

--- a/test/client-credentials-exchange.tests.js
+++ b/test/client-credentials-exchange.tests.js
@@ -34,8 +34,10 @@ describe('client-credentials-exchange', function () {
                 body: { client: { id: 'client' }, audience: 'audience' },
                 headers: {},
                 method: 'POST',
-            }, function (error, data) {
+            }, function (error, envelope) {
                 Assert.ifError(error);
+                Assert.ok(envelope);
+                const { data } = envelope;
                 Assert.ok(data);
                 Assert.equal(typeof data, 'object');
                 Assert.equal(typeof data.client, 'object');
@@ -60,8 +62,10 @@ describe('client-credentials-exchange', function () {
                 body: { client: { id: 'client' }, scope: ['scope'], audience: 'audience', context: { hello: 'world', foo: 'bar' } },
                 headers: {},
                 method: 'POST',
-            }, function (error, data) {
+            }, function (error, envelope) {
                 Assert.ifError(error);
+                Assert.ok(envelope);
+                const { data } = envelope;
                 Assert.ok(data);
                 Assert.equal(typeof data, 'object');
                 Assert.equal(typeof data.client, 'object');
@@ -93,8 +97,10 @@ describe('client-credentials-exchange', function () {
                 headers: {},
                 method: 'POST',
                 parseBody: false,
-            }, function (error, data) {
+            }, function (error, envelope) {
                 Assert.ifError(error);
+                Assert.ok(envelope);
+                const { data } = envelope;
                 Assert.ok(data);
                 Assert.equal(typeof data, 'object');
                 Assert.equal(typeof data.client, 'object');
@@ -126,8 +132,10 @@ describe('client-credentials-exchange', function () {
                 secrets: { 'auth0-extension-secret': 'foo' },
                 headers: { 'authorization': 'Bearer foo' },
                 method: 'POST',
-            }, function (error, data) {
+            }, function (error, envelope) {
                 Assert.ifError(error);
+                Assert.ok(envelope);
+                const { data } = envelope;
                 Assert.ok(data);
                 Assert.equal(typeof data, 'object');
                 Assert.equal(typeof data.client, 'object');
@@ -158,8 +166,9 @@ describe('client-credentials-exchange', function () {
                 body: { client: { id: 'client' }, scope: ['scope'], audience: 'audience' },
                 headers: { 'authorization': 'Bearer foo' },
                 method: 'POST',
-            }, function (error, data) {
+            }, function (error, envelope) {
                 Assert.ifError(error);
+                const { data } = envelope;
                 Assert.ok(data);
                 Assert.equal(typeof data, 'object');
                 Assert.equal(data.type, 'object');
@@ -282,6 +291,29 @@ describe('client-credentials-exchange', function () {
                 Assert.ok(error);
                 Assert.equal(error.statusCode, 500);
                 Assert.equal(data, undefined);
+                done();
+            });
+        });
+    });
+
+    it('transforms InvalidRequestErrors into an error payload', function (done) {
+        compiler({
+            nodejsCompiler,
+            script: 'module.exports = function(client, scope, audience, context, cb) { cb(new InvalidRequestError("bad request")); };'
+        }, function (error, func) {
+            Assert.ifError(error);
+
+            simulate(func, {
+                body: { client: { id: 'client' }, audience: 'audience' },
+                headers: {},
+                method: 'POST',
+            }, function (error, envelope) {
+                Assert.ifError(error);
+                Assert.ok(envelope);
+                const { result, data } = envelope;
+                Assert.ok(data);
+                Assert.equal(result, "oauth_error");
+                Assert.equal(data.error, "invalid_request");
                 done();
             });
         });


### PR DESCRIPTION
Getting feedback on an approach to send user errors back from client credentials in an "envelope" that doesn't actually respond with a 500 status code.