### PR TITLE
[MFA-391] Add SendPhoneMessageError

### DIFF
--- a/lib/compilers/send-phone-message.js
+++ b/lib/compilers/send-phone-message.js
@@ -3,7 +3,16 @@
 const Authz = require('../authorization');
 const Factory = require('./compilerFactory');
 
-module.exports = Factory.createCompiler(sendPhoneMessageHandler);
+const ExtensibilityUserError = require('../errors/ExtensibilityUserError');
+
+class SendPhoneMessageError extends ExtensibilityUserError {
+    constructor(message, friendlyMessage) {
+        super(message);
+        this.friendlyMessage = friendlyMessage || message;
+    }
+}
+
+module.exports = Factory.createCompiler(sendPhoneMessageHandler, [SendPhoneMessageError]);
 
 function sendPhoneMessageHandler (func, webtaskContext, cb) {
     return Authz.is_authorized(webtaskContext, error => {

--- a/test/send-phone-message.tests.js
+++ b/test/send-phone-message.tests.js
@@ -586,5 +586,45 @@ describe('send-phone-message', function () {
                 });
             });
         });
+
+        it('provides a custom error object', function (done) {
+            compiler({
+                nodejsCompiler,
+                script: 'module.exports = function(recipient, text, context, cb) { cb(new SendPhoneMessageError("e1", "e2")); };'
+            }, function (error, func) {
+                Assert.ifError(error);
+
+                simulate(func, {
+                    body: {
+                        recipient: '1-999-888-657-2134', text: 'dis iz a text', context: {
+                            message_type: 'sms',
+                            action: 'second-factor-authentication',
+                            language: 'korean',
+                            code: 'SOMEOTP12345',
+                            ip: '127.0.0.1',
+                            user_agent: 'someAgent',
+                            user: {},
+                            client: {
+                                client_id: 'someClientId',
+                                name: 'Test Application',
+                                client_metadata: {}
+                            }
+                        }
+                    },
+                    headers: {},
+                    method: 'POST',
+                }, function (error, envelope) {
+                    Assert.ifError(error);
+                    const { status, data } = envelope;
+                    Assert.equal(status, 'error');
+                    Assert.equal(data.name, 'SendPhoneMessageError');
+                    Assert.equal(data.message, 'e1');
+                    Assert.equal(data.friendlyMessage, 'e2');
+
+                    done();
+                });
+            });
+        });
+
     }); // valid payload
 });


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This PR adds support for returning a custom error from the SendPhoneMessage hook.

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
